### PR TITLE
Fixed Sticky Footer! Responsive on all screens.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -156,6 +156,7 @@ Page Styles
 .document-container {
 	width           : 100%;
 	padding-bottom  : 70px;
+	min-height      : calc(100vh - 36px); /* Sticky Footer Fixed ON ALL SCREENS - FIXED */
 }
 .main-header {
 	position        : fixed;
@@ -319,10 +320,9 @@ input[type="search"]:focus {
 Footer Styles
 ============================== */
 .footer {
-	min-height  : 30px;
-	background  : #0D5389;
-	opacity     : 0.9;
-	text-align  : center;
+	background       : #0D5389;
+	opacity          : 0.9;
+	text-align       : center;
 }
 
 .copyright {
@@ -376,9 +376,6 @@ Responsive - Media Queries
 		right   : 10vw;
 		width   : 80vw;
 		height  : 60vh;
-	}
-	.document-container {
-		min-height: calc(100vh - 36px); /* Sticky Footer Fixed */
 	}
 	.gallery {
 		padding-bottom: 50px;


### PR DESCRIPTION
The 'min-height' property is what makes it sticky at the bottom. That
declaration was only added to the 768px media query which is for tablets
only. I moved that declaration to the mobile screen, following the
mobile first approach.
